### PR TITLE
Make safe for concurrent use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = auto check diagnostic failing known skip todo writer yaml
+TESTS = auto check diagnostic failing known skip todo writer yaml parallel
 GOPATH ?= $(CURDIR)/gopath
 
 .PHONY: $(TESTS)
@@ -10,7 +10,7 @@ clean:
 	rm -f test/*/test
 
 test/%/test: test/%/*.go tap.go yaml_json.go yaml_yaml.go
-	go build -o $@ -tags yaml ./test/$*
+	go build -race -o $@ -tags yaml ./test/$*
 
 $(TESTS): %: test/%/test
 	prove -v -e '' test/$@/test

--- a/test/parallel/main.go
+++ b/test/parallel/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/mndrix/tap-go"
+)
+
+func main() {
+	t := tap.New()
+	t.Header(0)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 9; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c1 := t.Count()
+			t.Ok(true, "a test")
+			c2 := t.Count()
+			t.Ok(c2 > c1, "count up")
+			t.Skip(1, "skip")
+		}()
+	}
+	wg.Wait()
+
+	t.AutoPlan()
+}


### PR DESCRIPTION
- Add `sync.RWMutex` to `T`
- Lock when accessing to `T.nextTestNumber`